### PR TITLE
Only load images when they are needed by the carousel

### DIFF
--- a/artworks/carousel.js
+++ b/artworks/carousel.js
@@ -33,6 +33,7 @@ prevButton.addEventListener('click', e => {
         prevSlide = currentSlide.previousElementSibling;
     }
 
+    showImage(prevSlide);
     moveToSlide(track, currentSlide, prevSlide);
 });
 
@@ -48,7 +49,7 @@ nextButton.addEventListener('click', e => {
     } else {
         nextSlide = currentSlide.nextElementSibling;
     }
-
+    showImage(nextSlide);
     moveToSlide(track, currentSlide, nextSlide);
 });
 
@@ -58,6 +59,15 @@ const moveToSlide = (track, currentSlide, targetSlide) => {
     currentSlide.classList.remove('current-slide');
     targetSlide.classList.add('current-slide');
 }
+
+// Take the data-src attribute of the current slide and set it as the background image of the carousel
+const showImage = (slide) => {
+    const image = slide.querySelector('.carousel__image');
+    console.log('showImage', image.src)
+    if (image.src === '') {
+        image.src = image.dataset.src;
+    }
+};
 
 window.addEventListener('resize', init);
 init();

--- a/artworks/index.html
+++ b/artworks/index.html
@@ -62,150 +62,150 @@
                     <p class="art-caption"><em>The Space Between Stages</em> 2020 Oil and Acrylic on board 184 x 110cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-2" src="../illustrations/Artwork/Art piece 2.jpg" alt="">
+                    <img class="carousel__image image-2" data-src="../illustrations/Artwork/Art piece 2.jpg" alt="">
                     <p class="art-caption"><em>The Space Between Stages (Detail)</em> 2020 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-3" src="../illustrations/Artwork/Art piece 3.jpg" alt="">
+                    <img class="carousel__image image-3" data-src="../illustrations/Artwork/Art piece 3.jpg" alt="">
                     <p class="art-caption"><em>The Space Between Stages (Detail)</em> 2020 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-4" src="../illustrations/Artwork/Art piece 4.jpg" alt="">
+                    <img class="carousel__image image-4" data-src="../illustrations/Artwork/Art piece 4.jpg" alt="">
                     <p class="art-caption"><em>The Space Between Stages (Detail)</em> 2020 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-5" src="../illustrations/Artwork/Art piece 5.jpg" alt="">
+                    <img class="carousel__image image-5" data-src="../illustrations/Artwork/Art piece 5.jpg" alt="">
                     <p class="art-caption"><em>The Moon is Dead</em> 2020 Oil and Acrylic on board 30.4 x 30.4cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-6" src="../illustrations/Artwork/Art piece 6.jpg" alt="">
+                    <img class="carousel__image image-6" data-src="../illustrations/Artwork/Art piece 6.jpg" alt="">
                     <p class="art-caption"><em>Terminus</em> 2020 Oil and Acrylic on board 110 x 184cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-7" src="../illustrations/Artwork/Art piece 7.jpg" alt="">
+                    <img class="carousel__image image-7" data-src="../illustrations/Artwork/Art piece 7.jpg" alt="">
                     <p class="art-caption"><em>Terminus (Detail)</em> 2020 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-8" src="../illustrations/Artwork/Art piece 8.jpg" alt="">
+                    <img class="carousel__image image-8" data-src="../illustrations/Artwork/Art piece 8.jpg" alt="">
                     <p class="art-caption"><em>Monolith</em> 2020 Oil and Acrylic on board 110 x 184cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-9" src="../illustrations/Artwork/Art piece 9.jpg" alt="">
+                    <img class="carousel__image image-9" data-src="../illustrations/Artwork/Art piece 9.jpg" alt="">
                     <p class="art-caption"><em>Monolith (Detail)</em> 2020 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-10" src="../illustrations/Artwork/Art piece 10.jpg" alt="">
+                    <img class="carousel__image image-10" data-src="../illustrations/Artwork/Art piece 10.jpg" alt="">
                     <p class="art-caption"><em>Monolith (Detail)</em> 2020 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-11" src="../illustrations/Artwork/Art piece 11.jpg" alt="">
+                    <img class="carousel__image image-11" data-src="../illustrations/Artwork/Art piece 11.jpg" alt="">
                     <p class="art-caption"><em>Styx</em> 2021 Oil and Acrylic on board 165 x 120 cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-12" src="../illustrations/Artwork/Art piece 12.jpg" alt="">
+                    <img class="carousel__image image-12" data-src="../illustrations/Artwork/Art piece 12.jpg" alt="">
                     <p class="art-caption"><em>Styx (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-13" src="../illustrations/Artwork/Art piece 13.jpg" alt="">
+                    <img class="carousel__image image-13" data-src="../illustrations/Artwork/Art piece 13.jpg" alt="">
                     <p class="art-caption"><em>Styx (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-14" src="../illustrations/Artwork/Art piece 14.jpg" alt="">
+                    <img class="carousel__image image-14" data-src="../illustrations/Artwork/Art piece 14.jpg" alt="">
                     <p class="art-caption"><em>Following A Faint Stain On The Air Down To The River’s edge</em> 2022 Oil on board 165 x 120cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-15" src="../illustrations/Artwork/Art piece 15.jpg" alt="">
+                    <img class="carousel__image image-15" data-src="../illustrations/Artwork/Art piece 15.jpg" alt="">
                     <p class="art-caption"><em>Following A Faint Stain On The Air Down To The River’s edge (Detail)</em> 2022 Oil on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-16" src="../illustrations/Artwork/Art piece 16.jpg" alt="">
+                    <img class="carousel__image image-16" data-src="../illustrations/Artwork/Art piece 16.jpg" alt="">
                     <p class="art-caption"><em>Following A Faint Stain On The Air Down To The River’s edge (Detail)</em> 2022 Oil on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-17" src="../illustrations/Artwork/Art piece 17.jpg" alt="">
+                    <img class="carousel__image image-17" data-src="../illustrations/Artwork/Art piece 17.jpg" alt="">
                     <p class="art-caption"><em>The River Speaks</em> 2022 Oil and Acrylic on Board 110 x 184cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-18" src="../illustrations/Artwork/Art piece 18.jpg" alt="">
+                    <img class="carousel__image image-18" data-src="../illustrations/Artwork/Art piece 18.jpg" alt="">
                     <p class="art-caption"><em>The River Speaks (Detail)</em> 2022 Oil and Acrylic on Board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-19" src="../illustrations/Artwork/Art piece 19.jpg" alt="">
+                    <img class="carousel__image image-19" data-src="../illustrations/Artwork/Art piece 19.jpg" alt="">
                     <p class="art-caption"><em>Tristis Citus</em> 2021 Oil and Acrylic on board 50 x 100cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-20" src="../illustrations/Artwork/Art piece 20.jpg" alt="">
+                    <img class="carousel__image image-20" data-src="../illustrations/Artwork/Art piece 20.jpg" alt="">
                     <p class="art-caption"><em>The Performer And His Wife</em> 2021 Oil and Acrylic on board 110 x 184cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-21" src="../illustrations/Artwork/Art piece 21.jpg" alt="">
+                    <img class="carousel__image image-21" data-src="../illustrations/Artwork/Art piece 21.jpg" alt="">
                     <p class="art-caption"><em>The Performer And His Wife (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-22" src="../illustrations/Artwork/Art piece 22.jpg" alt="">
+                    <img class="carousel__image image-22" data-src="../illustrations/Artwork/Art piece 22.jpg" alt="">
                     <p class="art-caption"><em>The Performer And His Wife (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-23" src="../illustrations/Artwork/Art piece 23.jpg" alt="">
+                    <img class="carousel__image image-23" data-src="../illustrations/Artwork/Art piece 23.jpg" alt="">
                     <p class="art-caption"><em>The Performer And His Wife (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <!-- <li class="carousel__slide">
-                    <img class="carousel__image image-24" src="../illustrations/Artwork/Art piece 24.jpg" alt="">
+                    <img class="carousel__image image-24" data-src="../illustrations/Artwork/Art piece 24.jpg" alt="">
                     <p class="art-caption"><em>The Performer And His Wife (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li> -->
                 <li class="carousel__slide">
-                    <img class="carousel__image image-25" src="../illustrations/Artwork/Art piece 25.jpg" alt="">
+                    <img class="carousel__image image-25" data-src="../illustrations/Artwork/Art piece 25.jpg" alt="">
                     <p class="art-caption"><em>Dead Objects</em> 2021 Oil and Acrylic on board 110 x 184cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-26" src="../illustrations/Artwork/Art piece 26.jpg" alt="">
+                    <img class="carousel__image image-26" data-src="../illustrations/Artwork/Art piece 26.jpg" alt="">
                     <p class="art-caption"><em>Dead Objects (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-27" src="../illustrations/Artwork/Art piece 27.jpg" alt="">
+                    <img class="carousel__image image-27" data-src="../illustrations/Artwork/Art piece 27.jpg" alt="">
                     <p class="art-caption"><em>Dead Objects (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-28" src="../illustrations/Artwork/Art piece 28.jpg" alt="">
+                    <img class="carousel__image image-28" data-src="../illustrations/Artwork/Art piece 28.jpg" alt="">
                     <p class="art-caption"><em>Mustard Air</em> 2022 Gouache on Paper 11 x 20cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-29" src="../illustrations/Artwork/Art piece 29.jpg" alt="">
+                    <img class="carousel__image image-29" data-src="../illustrations/Artwork/Art piece 29.jpg" alt="">
                     <p class="art-caption"><em>Ghost Pizza</em> 2021 Found Object NFS</p>
                 </li>
 
                 <li class="carousel__slide">
-                    <img class="carousel__image image-30" src="../illustrations/Artwork/Art piece 30.jpg" alt="">
+                    <img class="carousel__image image-30" data-src="../illustrations/Artwork/Art piece 30.jpg" alt="">
                     <p class="art-caption"><em>The Witness I</em> 2021 Oil and Acrylic on board 184 x 110cm</p>
                 </li>
 
                 <li class="carousel__slide">
-                    <img class="carousel__image image-31" src="../illustrations/Artwork/Art piece 31.jpg" alt="">
+                    <img class="carousel__image image-31" data-src="../illustrations/Artwork/Art piece 31.jpg" alt="">
                     <p class="art-caption"><em>The Witness II</em> 2021 Oil and Acrylic on board 184 x 110cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-32" src="../illustrations/Artwork/Art piece 32.jpg" alt="">
+                    <img class="carousel__image image-32" data-src="../illustrations/Artwork/Art piece 32.jpg" alt="">
                     <p class="art-caption"><em>The Witness II (Detail)</em> 2021 Oil and Acrylic on board</p>
                 </li>
-                
+
                 <li class="carousel__slide">
-                    <img class="carousel__image image-33" src="../illustrations/Artwork/Art piece 33.jpg" alt="">
+                    <img class="carousel__image image-33" data-src="../illustrations/Artwork/Art piece 33.jpg" alt="">
                     <p class="art-caption"><em>Look Behind You! Remember That You Are A Man! Remember That You Will Die!</em> 2020 Oil and Acrylic and Oil Pastel on board 250 x 184cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-34" src="../illustrations/Artwork/Art piece 34.jpg" alt="">
+                    <img class="carousel__image image-34" data-src="../illustrations/Artwork/Art piece 34.jpg" alt="">
                     <p class="art-caption"><em>Look Behind! You Remember That You Are A Man! Remember That You Will Die! (Details)</em> 2020 Oil and Acrylic and Oil Pastel on board</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-35" src="../illustrations/Artwork/Art piece 35.jpg" alt="">
+                    <img class="carousel__image image-35" data-src="../illustrations/Artwork/Art piece 35.jpg" alt="">
                     <p class="art-caption"><em>It Can’t Always Be Night</em> 2022 Oil and Graphite on Board and Paper 165 x 120cm</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-36" src="../illustrations/Artwork/Art piece 36.jpg" alt="">
+                    <img class="carousel__image image-36" data-src="../illustrations/Artwork/Art piece 36.jpg" alt="">
                     <p class="art-caption"><em>It Can’t Always Be Night</em> (Detail) 2022 Oil and Graphite on Board and Paper</p>
                 </li>
                 <li class="carousel__slide">
-                    <img class="carousel__image image-37" src="../illustrations/Artwork/Art piece 37.jpg" alt="">
+                    <img class="carousel__image image-37" data-src="../illustrations/Artwork/Art piece 37.jpg" alt="">
                     <p class="art-caption"><em>It Can’t Always Be Night (Detail) 2022 Oil and Graphite on Board and Paper</p>
                 </li>
             </ul>


### PR DESCRIPTION
## Done
Charges `src` to `data-src` for all but the first image.
Added a function in carousel.js to set the `src` to the same value as `data-src` if it is not already set.

## QA
1. Run the site
2. Go to /artworks
3. See is loads quickly
4. Click next and previous and see it works as normal
5. Look at what is happening to the image elements in the inspector